### PR TITLE
Update broken link

### DIFF
--- a/conf/solr.xml
+++ b/conf/solr.xml
@@ -20,7 +20,7 @@ detected.
   <!--  + war OR resourceBase                                          -->
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
   <Set name="contextPath">/solr</Set>
-  <Set name="war"><SystemProperty name="jetty.home" default="."/>/webapps/apache-solr-3.3.0.war</Set>
+  <Set name="war"><SystemProperty name="jetty.home" default="."/>/webapps/apache-solr-3.6.2.war</Set>
 
   <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
   <!-- Optional context configuration                                  -->

--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ sudo cp $BASEDIR/conf/jetty.xml $JETTY_HOME/etc/jetty.xml
 #Download and Install Apache Solr
 echo "Download and Install Apache Solr"
 cd $TMP
-wget http://apache.mirrors.timporter.net/lucene/solr/3.6.2/apache-solr-3.6.2.tgz
+wget http://archive.apache.org/dist/lucene/solr/3.6.2/apache-solr-3.6.2.tgz
 tar -xzf apache-solr-3.6.2.tgz
 rm apache-solr-3.6.2.tgz
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # -e: Exit immediately if a command exits with a non-zero status.
 
 # Install dependencies depending of the distribution family

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e	 	
+#!/bin/bash
 # -e: Exit immediately if a command exits with a non-zero status.
 
 # Install dependencies depending of the distribution family


### PR DESCRIPTION
This link should be the once-and-final change as 3.6.2 is no longer available on mirrors.

http://archive.apache.org/dist/lucene/solr/3.6.2/apache-solr-3.6.2.tgz
